### PR TITLE
Improve docs and ease deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ end
 
 Find the required fields for a strategy under its module definition at [hexdocs.pm/litestream](https://hexdocs.pm/litestream).
 
+### On Container Deployments
+
+In minimal container environments the `SHELL` environment variable is often unset. This is required by `erlexec` which handles the Litestream process, so the library detects this and defaults SHELL to `/bin/sh` automatically — if you see a warning in your logs about it, that is expected and safe to ignore.
+
 ## Attribution
 
 - The logo for the project is an edited version of an SVG image from the [unDraw project](https://undraw.co/)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ def deps do
 end
 ```
 
+**Note:** On first start, the Litestream binary is downloaded and written to `priv/litestream/`
+inside your application. This path should be added to your `.gitignore` to avoid accidentally
+committing a platform-specific binary that may be incompatible with your deployment target:
+```
+/priv/litestream/
+```
+
 Documentation can be found at [hexdocs.pm/litestream](https://hexdocs.pm/litestream).
 
 ## Supporting Litestream

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Checkout my [GitHub Sponsorship page](https://github.com/sponsors/akoutmos) if y
 
 ## Setting Up Litestream
 
-After adding `{:litestream, "~> 0.4.0"}` in your `mix.exs` file and running `mix deps.get`, open your `application.ex`
+After adding `{:litestream, "~> 0.5.0"}` in your `mix.exs` file and running `mix deps.get`, open your `application.ex`
 file and add the following to your supervision tree:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -111,10 +111,7 @@ config :my_app, Litestream,
 ```
 
 With those in place, you should be all set to go! As soon as your application starts, your database will be
-automatically synced with your remote destination.
-
-> **Note:** `Litestream.Strategy.LocalFile` is suitable for development and testing only. For production
-> deployments you should use one of the cloud-backed strategies listed below.
+automatically synced using your chosen backup strategy.
 
 ### Backup Strategies
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,50 @@ config :my_app, Litestream,
 With those in place, you should be all set to go! As soon as your application starts, your database will be
 automatically synced with your remote destination.
 
+> **Note:** `Litestream.Strategy.LocalFile` is suitable for development and testing only. For production
+> deployments you should use one of the cloud-backed strategies listed below.
+
+### Backup Strategies
+
+The following strategies are available under the `Litestream.Strategy` namespace for configuration in `runtime.exs`:
+
+| Strategy | Destination |
+|---|---|
+| `LocalFile` | Local filesystem (development/testing only) |
+| `ObjectStorage` | Any S3-compatible store (AWS S3, etc.) |
+| `AzureBlobStorage` | Azure Blob Storage |
+| `BackblazeB2` | Backblaze B2 |
+| `CloudflareR2` | Cloudflare R2 |
+| `DigitalOceanSpaces` | DigitalOcean Spaces |
+| `Firebase` | Firebase Storage |
+| `GoogleCloudStorage` | Google Cloud Storage |
+| `LinodeObjectStorage` | Linode Object Storage |
+| `Minio` | MinIO |
+| `NatsJetstream` | NATS JetStream Object Store |
+| `ScalewayObjectStorage` | Scaleway Object Storage |
+| `SFTP` | SFTP server |
+| `SupabaseStorage` | Supabase Storage |
+| `Tigris` | Tigris |
+| `Custom` | BYO Litestream YAML config file |
+
+For example, to back up to an S3-compatible store in production:
+
+```elixir
+if config_env() == :prod do
+# ... #
+config :my_app, Litestream,
+  repo: MyApp.Repo,
+  strategy: %Litestream.Strategy.ObjectStorage{
+    access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
+    secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
+    url: System.fetch_env!("LITESTREAM_REPLICA_URL")
+  }
+# ... #
+end
+```
+
+Find the required fields for a strategy under its module definition at [hexdocs.pm/litestream](https://hexdocs.pm/litestream).
+
 ## Attribution
 
 - The logo for the project is an edited version of an SVG image from the [unDraw project](https://undraw.co/)

--- a/lib/litestream.ex
+++ b/lib/litestream.ex
@@ -81,6 +81,7 @@ defmodule Litestream do
 
   @impl true
   def init(state) do
+    ensure_shell_set_for_erlexec()
     repo_config = state.repo.config()
     otp_app = Keyword.fetch!(repo_config, :otp_app)
     database_file = Keyword.fetch!(repo_config, :database)
@@ -250,6 +251,16 @@ defmodule Litestream do
         temp_path = Path.join(System.tmp_dir!(), "litestream-#{:erlang.unique_integer([:positive])}.yml")
         File.write!(temp_path, file_contents)
         Map.put(strategy, :temp_config_path, temp_path)
+    end
+  end
+
+  # erlexec checks for SHELL at startup and exits if it's absent
+  defp ensure_shell_set_for_erlexec do
+    sh = System.get_env("SHELL")
+
+    if sh == nil || sh == "" do
+      System.put_env("SHELL", "/bin/sh")
+      Logger.warning("SHELL environment variable not set; defaulting to /bin/sh for erlexec compatibility")
     end
   end
 end

--- a/lib/litestream/strategy/supabase_storage.ex
+++ b/lib/litestream/strategy/supabase_storage.ex
@@ -1,7 +1,7 @@
 defmodule Litestream.Strategy.SupabaseStorage do
   @moduledoc """
   Use this strategy for backing up your SQLite DB file to
-  Suprabase Storage.
+  Supabase Storage.
   """
 
   alias __MODULE__

--- a/lib/replicator.ex
+++ b/lib/replicator.ex
@@ -20,9 +20,10 @@ defprotocol Litestream.Replicator do
   def cli_args(struct, database)
 
   @doc """
-  If the strategy requires a temporary file for it's configuration, this function
-  will provide the
+  If the strategy requires a temporary file for its configuration, this function
+  will provide the contents of that file as a string. If no temporary file is
+  required, this function should return `nil`.
   """
-  @spec temp_file_contents(struct :: t(), database :: String.t()) :: temp_file_contents :: String.t()
+  @spec temp_file_contents(struct :: t(), database :: String.t()) :: String.t() | nil
   def temp_file_contents(struct, database)
 end


### PR DESCRIPTION
## Documentation improvements + one deployment improvement

Thanks for the v0.5.x upgrade! I installed this on another one of my projects recently. I ran into some gaps in the docs I thought could be improved, and I hit a snag when deploying to Fly.

### Docs

- The "Setting Up" section was still referencing `~> 0.4.0` — bumped to `~> 0.5.0`.
- Added a strategies table so it's obvious which destinations are available.
- Added a note under Installation about keeping the binary out of `git` — it's easy to accidentally commit a macOS build and then wonder why your Linux deployment doesn't start (I know from experience).
- Completed a cut-off sentence in the `Litestream.Replicator.temp_file_contents/2` doc, fixed a
  possessive ("it's" → "its"), and corrected the `@spec` return type to `String.t() | nil` since
  most strategies return `nil`.
- Fixed a typo in `Litestream.Strategy.SupabaseStorage` — the module doc said "Suprabase".

### Erlexec / SHELL fix

When I deployed to Fly.io the entire BEAM was crashing on startup with:

```
SHELL environment variable not set! [exec.cpp:627]
Application erlexec exited: failed to start child: :exec
** (EXIT) {:port_exited_with_status, 4}
Kernel pid terminated (application_controller)
```

Turns out `erlexec` requires `SHELL` to be set in the process environment, and in minimal container environments (Alpine, Fly.io) `SHELL` can be absent. At least, it was for me.

The fix I landed on in production was `SHELL = "/bin/sh"` in `fly.toml`, but it seems worth
handling in the library itself so others don't have to debug this. Thoughts? I'm wary this may be an overstep - I could also add a note in the docs to call out the issue, I just thought it'd be neat to handle it here.